### PR TITLE
Add PLC interfaces and update imports

### DIFF
--- a/src/components/LadderComponent.tsx
+++ b/src/components/LadderComponent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDrag } from 'react-dnd';
 import { Edit2, Trash2 } from 'lucide-react';
-import { Component } from '../types/plc';
+import { Component } from '../types/project';
 import { GRID_SIZE, RAIL_WIDTH } from '../utils/gridSystem';
 
 interface LadderComponentProps {

--- a/src/reducers/ladderReducer.ts
+++ b/src/reducers/ladderReducer.ts
@@ -1,4 +1,4 @@
-import { ProjectData, Component } from '../types/plc';
+import { ProjectData, Component } from '../types/project';
 
 export type LadderAction = 
   | { type: 'ADD_COMPONENT'; rungIndex: number; component: Component }

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -1,4 +1,4 @@
-import { ProjectData, POU } from '../types/plc';
+import { ProjectData, POU } from '../types/project';
 import { fileService } from './FileService';
 import { toastService } from './ToastService';
 

--- a/src/types/plc.ts
+++ b/src/types/plc.ts
@@ -1,11 +1,20 @@
 // Update the LineSegmentType
-export type LineSegmentType = 
+export type LineSegmentType =
   | 'horizontal' 
   | 'vertical' 
   | 'L-up'    // Up and either left or right
   | 'L-down'  // Down and either left or right
   | 'T'       // T-shaped connection
   | 'none';
+
+export interface Component {
+  id?: string;
+  type: string;
+  position: number;
+  width?: number;
+  variables?: Record<string, any>;
+  icon?: any;
+}
 
 export interface GridSegment {
   id: string;
@@ -28,4 +37,23 @@ export interface VerticalLink {
   toRung: number;
   fromPosition: number;
   toPosition: number;
+}
+
+export interface POU {
+  id: string;
+  name: string;
+  type: string;
+  variables: {
+    input: any[];
+    output: any[];
+    local: any[];
+  };
+  rungs: Rung[];
+}
+
+export interface ProjectData {
+  name: string;
+  rungs: Rung[];
+  settings: Record<string, any>;
+  pous?: POU[];
 }

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,1 +1,1 @@
-export * from './plc';
+export type { Component, ProjectData, POU, Rung, GridSegment, VerticalLink } from './plc';


### PR DESCRIPTION
## Summary
- define `Component` and `ProjectData` interfaces in `plc.ts`
- export PLC types via `project.ts`
- switch imports to use the consolidated `project` types